### PR TITLE
feat: forward optional sentry_auth_token as buildkit secret

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -46,6 +46,8 @@ on:
           required: true
       bundle_token:
           required: false
+      sentry_auth_token:
+          required: false
     outputs:
       tag:
         description: 'Tag version'
@@ -101,6 +103,8 @@ jobs:
             APP_VERSION=${{ steps.get_tag_version.outputs.new_tag }}
             BUNDLE_WITHOUT=${{ env.BUNDLE_WITHOUT }}
             ${{ inputs.build_args }}
+          secrets: |
+            sentry_auth_token=${{ secrets.sentry_auth_token }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Bump version and push tag

--- a/.github/workflows/yc_build_and_push.yaml
+++ b/.github/workflows/yc_build_and_push.yaml
@@ -51,6 +51,8 @@ on:
         required: false
       npm_package_token:
         required: false
+      sentry_auth_token:
+        required: false
     outputs:
       tag:
         description: "Tag version"
@@ -119,6 +121,8 @@ jobs:
             BUNDLE_WITHOUT=${{ env.BUNDLE_WITHOUT }}
             NPM_PACKAGE_TOKEN=${{ env.NPM_PACKAGE_TOKEN }}
             ${{ inputs.build_args }}
+          secrets: |
+            sentry_auth_token=${{ secrets.sentry_auth_token }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## What

Adds an optional `sentry_auth_token` `workflow_call` secret to both reusable build workflows and forwards it to `docker/build-push-action` via `secrets:`:

- `.github/workflows/build_and_push.yaml` (AWS ECR)
- `.github/workflows/yc_build_and_push.yaml` (Yandex CR)

## Why

Consumers need to pass a Sentry auth token into the image build (e.g. esbuild's `@sentry/esbuild-plugin` uploading sourcemaps during `yarn build`). Passing it as a build-arg leaks into the builder stage's provenance and the `type=gha,mode=max` cache. A BuildKit **secret mount** never persists in layers, the pushed image, or the cache.

## Consumer usage

Caller passes the secret:

```yaml
    secrets:
      sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
```

Dockerfile consumes it only where needed:

```dockerfile
RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN yarn build
```

## Compatibility

`required: false` — existing callers that don't pass the secret are unaffected (empty mount id, plugin stays disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)